### PR TITLE
🚀 GitHub Pages デプロイ設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "export",
+  basePath: "/portfolio",
+  trailingSlash: true,
+  images: { unoptimized: true },
 };
 
 export default nextConfig;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { gsap } from "gsap";
+import Link from "next/link";
 
 const navLinks = [
   { href: "/#about", label: "About" },
@@ -40,22 +41,22 @@ export default function Navigation() {
           : ""
       }`}
     >
-      <a href="#home" className="nav-logo opacity-0">
+      <Link href="/" className="nav-logo opacity-0">
         <span className="text-lg font-black tracking-tight bg-gradient-to-r from-cyan-400 to-teal-400 bg-clip-text text-transparent">
           KS.
         </span>
-      </a>
+      </Link>
 
       <ul className="flex items-center gap-8">
         {navLinks.map((link) => (
           <li key={link.href}>
-            <a
+            <Link
               href={link.href}
               className="nav-link opacity-0 text-xs font-medium text-white/50 hover:text-white transition-colors duration-200 tracking-[0.15em] uppercase relative group"
             >
               {link.label}
               <span className="absolute -bottom-0.5 left-0 w-0 h-px bg-gradient-to-r from-cyan-400 to-teal-400 group-hover:w-full transition-all duration-300" />
-            </a>
+            </Link>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary

- Next.js の静的エクスポート設定追加
- GitHub Actions によるデプロイワークフロー作成
- Navigation を Next.js Link コンポーネントに変更（basePath 自動対応）

## Changes

- **next.config.ts**: `output: 'export'`, `basePath: '/portfolio'`, `trailingSlash`, `images.unoptimized`
- **.github/workflows/deploy.yml**: main push 時に自動ビルド → GitHub Pages デプロイ
- **Navigation.tsx**: `<a>` → `<Link>` に変更

## マージ後の手順

1. GitHub リポジトリの **Settings → Pages**
2. Source を **GitHub Actions** に変更
3. しばらく待つと `https://lud7n.github.io/portfolio/` で公開される