### PR TITLE
feat: navigation redesign with full-screen menu

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -163,8 +163,8 @@ export default function Navigation() {
       {/* フルスクリーンメニュー */}
       <div
         ref={menuRef}
-        className="fixed inset-0 z-40 hidden flex-col justify-center overflow-hidden backdrop-blur-2xl"
-        style={{ background: "rgba(10,10,10,0.75)" }}
+        className="fixed inset-0 z-40 hidden flex-col justify-center overflow-hidden backdrop-blur-md"
+        style={{ background: "rgba(10,10,10,0.6)" }}
         onMouseMove={handleMenuMouseMove}
       >
         {/* B: リンクごとのアクセントグラデーション */}


### PR DESCRIPTION
## Summary

- ハンバーガーボタン + フルスクリーンメニューへ全面刷新
- アクティブセクション検出によるハイライト表示
- 4つのインタラクティブエフェクト追加

## Interactive Effects

- **B**: リンクホバーでページごとのアクセントカラーグラデーション出現
- **C**: スポットライトがカーソルに追従
- **D**: ホバー時に他リンクが暗転しフォーカス集中
- **E**: リンクが左右交互の方向から入場

## その他

- メニュー背景を半透明 + ぼかし（backdrop-blur-md）でページが透けて見える
- アクティブセクションに `— now` ラベル表示

closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)