### PR TITLE
feat: Skillsページにオーロラ背景・ナビホームボタン追加

### DIFF
--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import Link from "next/link";
+import SkillsAurora from "@/components/SkillsAurora";
 import {
   SiFigma,
   SiTypescript,
@@ -444,14 +445,18 @@ export default function Skills() {
   }, []);
 
   return (
-    <main className="min-h-screen text-white relative" style={{ background: "#050810" }}>
-      {/* H: ノイズテクスチャオーバーレイ */}
+    <main className="min-h-screen text-white relative" style={{ background: "transparent" }}>
+      {/* ベース背景色 */}
+      <div aria-hidden style={{ position: "fixed", inset: 0, zIndex: 0, background: "#050810" }} />
+      {/* オーロラシェーダー */}
+      <SkillsAurora />
+      {/* ノイズテクスチャオーバーレイ */}
       <div
         aria-hidden
         style={{
           position: "fixed",
           inset: 0,
-          zIndex: 0,
+          zIndex: 2,
           pointerEvents: "none",
           opacity: 0.035,
           backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -155,6 +155,22 @@ export default function Navigation() {
           <span className="block h-px bg-white origin-center transition-all duration-300 w-full"
             style={{ transform: menuOpen ? "translateY(-9px) rotate(-45deg)" : "none" }} />
         </button>
+
+        {/* ホームボタン（ホーム以外のページで表示） */}
+        {pathname !== "/" && !menuOpen && (
+          <Link
+            href="/"
+            className="flex items-center gap-2 group"
+            style={{ color: "rgba(255,255,255,0.3)", transition: "color 0.3s" }}
+            onMouseEnter={e => (e.currentTarget.style.color = "rgba(255,255,255,0.8)")}
+            onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.3)")}
+          >
+            <svg width="16" height="16" viewBox="0 0 14 14" fill="none">
+              <path d="M1 6.5L7 1L13 6.5V13H9.5V9.5H4.5V13H1V6.5Z"
+                stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+            </svg>
+          </Link>
+        )}
       </nav>
 
       {/* フルスクリーンメニュー */}

--- a/src/components/SkillsAurora.tsx
+++ b/src/components/SkillsAurora.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export default function SkillsAurora() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let scrollY = 0;
+    const onScroll = () => { scrollY = window.scrollY; };
+    window.addEventListener("scroll", onScroll, { passive: true });
+
+    const resize = () => {
+      canvas.width  = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    let raf = 0;
+    let t = 0;
+
+    // シンプルなノイズ代わりにsin/cosを組み合わせた疑似オーロラ
+    const render = () => {
+      t += 0.004;
+      const w = canvas.width;
+      const h = canvas.height;
+      const scroll = scrollY * 0.0003;
+
+      ctx.clearRect(0, 0, w, h);
+
+      // 3〜4個の楕円グラデーションをブレンド
+      // scrollで色相をわずかにシフトさせつつ、ブロブはビューポート全体をカバー
+      const s = scroll * 0.15;
+      const blobs = [
+        { x: 0.25 + Math.sin(t * 0.7) * 0.12, y: 0.25 + Math.cos(t * 0.5) * 0.08 + s, rx: 0.65, ry: 0.5,  color: "99,102,241",   alpha: 0.38 },
+        { x: 0.78 + Math.cos(t * 0.6) * 0.1,  y: 0.5  + Math.sin(t * 0.4) * 0.1  + s, rx: 0.6,  ry: 0.48, color: "139,92,246",  alpha: 0.32 },
+        { x: 0.5  + Math.sin(t * 0.5) * 0.09, y: 0.15 + Math.cos(t * 0.8) * 0.07 + s, rx: 0.5,  ry: 0.4,  color: "6,182,212",   alpha: 0.25 },
+        { x: 0.15 + Math.cos(t * 0.9) * 0.07, y: 0.72 + Math.sin(t * 0.6) * 0.08 + s, rx: 0.45, ry: 0.38, color: "129,140,248", alpha: 0.28 },
+        { x: 0.65 + Math.sin(t * 0.4) * 0.08, y: 0.85 + Math.cos(t * 0.7) * 0.07 + s, rx: 0.5,  ry: 0.42, color: "99,102,241",  alpha: 0.25 },
+        { x: 0.35 + Math.cos(t * 0.5) * 0.1,  y: 0.62 + Math.sin(t * 0.5) * 0.08 + s, rx: 0.45, ry: 0.36, color: "139,92,246",  alpha: 0.22 },
+      ];
+
+      ctx.save();
+      ctx.globalCompositeOperation = "screen";
+
+      for (const b of blobs) {
+        const cx = b.x * w;
+        const cy = b.y * h;
+        const rx = b.rx * w;
+        const ry = b.ry * h;
+
+        const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, Math.max(rx, ry));
+        grad.addColorStop(0,   `rgba(${b.color}, ${b.alpha})`);
+        grad.addColorStop(0.5, `rgba(${b.color}, ${b.alpha * 0.4})`);
+        grad.addColorStop(1,   `rgba(${b.color}, 0)`);
+
+        ctx.save();
+        ctx.scale(1, ry / rx);
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.arc(cx, cy * (rx / ry), rx, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+      }
+
+      ctx.restore();
+      raf = requestAnimationFrame(render);
+    };
+
+    raf = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1,
+        pointerEvents: "none",
+        width: "100vw",
+        height: "100vh",
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## 概要
- Canvas 2D APIを使ったオーロラ状の背景エフェクト（SkillsAurora）をSkillsページに追加
- indigo / violet / cyan の6つのグローブロブがゆっくり揺らめき、スクロールに連動
- ナビゲーションバーにホーム以外のページで表示されるホームアイコンボタンを追加

## 変更の背景・目的
Skillsページの背景が真っ黒で単調だったため、ブランドカラーを使ったオーロラエフェクトで視覚的な奥行きを追加。また、サブページからトップページへ戻るインターフェースがなかったため、ナビバーにホームアイコンを追加。

## テスト項目
- [ ] ビルドが通ること
- [ ] /skills でオーロラ背景が表示されること
- [ ] スクロール時もオーロラが画面全体に広がること
- [ ] ホーム以外のページでナビ右側にホームアイコンが表示されること
- [ ] ホームアイコンクリックで / に遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)