### PR TITLE
feat: ページ遷移フェードアニメーション実装

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import CustomCursor from "@/components/CustomCursor";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import ScrollCTA from "@/components/ScrollCTA";
+import TransitionOverlay from "@/components/TransitionOverlay";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -32,6 +33,7 @@ export default function RootLayout({
             {children}
             <Footer />
             <ScrollCTA />
+            <TransitionOverlay />
           </div>
         </SmoothScrollProvider>
       </body>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -60,7 +60,7 @@ export default function About() {
       ref={sectionRef}
       id="about"
       className="w-full"
-      style={{ paddingTop: "14rem", paddingBottom: "8rem" }}
+      style={{ paddingTop: "9rem", paddingBottom: "6rem" }}
     >
       <div className="max-w-5xl mx-auto" style={{ paddingLeft: "clamp(2rem, 5vw, 5rem)", paddingRight: "clamp(2rem, 5vw, 5rem)" }}>
         <div className="max-w-2xl">

--- a/src/components/Certifications.tsx
+++ b/src/components/Certifications.tsx
@@ -94,7 +94,7 @@ export default function Certifications() {
       ref={sectionRef}
       id="certifications"
       className="w-full"
-      style={{ paddingTop: "14rem", paddingBottom: "8rem" }}
+      style={{ paddingTop: "9rem", paddingBottom: "6rem" }}
     >
       <div className="max-w-5xl mx-auto" style={{ paddingLeft: "clamp(2rem, 5vw, 5rem)", paddingRight: "clamp(2rem, 5vw, 5rem)" }}>
         <h2 className="cert-heading text-5xl md:text-6xl font-black leading-tight tracking-tight" style={{ marginBottom: "1.5rem" }}>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useRef } from "react";
 import { gsap } from "gsap";
 import Link from "next/link";
+import { navigateTo } from "@/lib/pageTransition";
 import { usePathname } from "next/navigation";
 import { lenisInstance } from "@/components/SmoothScrollProvider";
 
@@ -265,7 +266,12 @@ export default function Navigation() {
                 href={link.href}
                 className="group flex items-baseline gap-5"
                 style={{ fontSize: "clamp(28px, 4vw, 52px)" }}
-                onClick={() => { setMenuOpen(false); lenisInstance?.scrollTo(0, { immediate: true }); }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  setMenuOpen(false);
+                  lenisInstance?.scrollTo(0, { immediate: true });
+                  navigateTo(link.href);
+                }}
               >
                 {/* D: ホバーで他リンクが暗くなる */}
                 <span

--- a/src/components/ScrollCTA.tsx
+++ b/src/components/ScrollCTA.tsx
@@ -2,59 +2,22 @@
 
 import { useRef } from "react";
 import { gsap } from "gsap";
-import { useRouter } from "next/navigation";
 import { FaCode, FaLayerGroup, FaHeart, FaFeather } from "react-icons/fa";
 import type { IconType } from "react-icons";
-
-// ── A: カラー Circle Reveal ──────────────────────────────
-function runColorReveal(originEl: HTMLElement, color: string, onDone: () => void) {
-  const rect = originEl.getBoundingClientRect();
-  const ox   = rect.left + rect.width  / 2;
-  const oy   = rect.top  + rect.height / 2;
-  const size = rect.width;
-
-  const div = document.createElement("div");
-  div.style.cssText = `
-    position: fixed; z-index: 9999; border-radius: 50%;
-    background: ${color}; pointer-events: none;
-    width: ${size}px; height: ${size}px;
-    left: ${ox - size / 2}px; top: ${oy - size / 2}px;
-    transform: scale(1); transform-origin: center center;
-  `;
-  document.body.appendChild(div);
-
-  const maxDist = Math.sqrt(window.innerWidth ** 2 + window.innerHeight ** 2);
-  gsap.to(div, {
-    scale: (maxDist * 2) / size,
-    duration: 0.65,
-    ease: "power3.inOut",
-    onComplete: () => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          onDone();
-          setTimeout(() => { if (document.body.contains(div)) document.body.removeChild(div); }, 500);
-        });
-      });
-    },
-  });
-}
+import { navigateTo } from "@/lib/pageTransition";
 
 // ── Button ───────────────────────────────────────────────
-type RevealMode = { type: "color"; color: string };
-
 type ButtonColor = { ring: string; glow: string; label: string };
 
 function CTAButton({
-  label, href, reveal, Icon, iconClass, color,
+  label, href, Icon, iconClass, color,
 }: {
   label: string;
   href: string;
-  reveal: RevealMode;
   Icon: IconType;
   iconClass: string;
   color: ButtonColor;
 }) {
-  const router = useRouter();
   const btnRef = useRef<HTMLAnchorElement>(null);
 
   const handleMouseEnter = () => {
@@ -87,8 +50,7 @@ function CTAButton({
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
-    const ring = btnRef.current?.querySelector(".cta-ring") as HTMLElement;
-    runColorReveal(ring ?? (btnRef.current as HTMLElement), reveal.color, () => router.push(href));
+    navigateTo(href);
   };
 
   return (
@@ -166,25 +128,21 @@ export default function ScrollCTA() {
       <div className="fixed bottom-10 left-1/2 -translate-x-1/2 z-40 flex items-end gap-8">
         <CTAButton
           label="Skills" href="/skills"
-          reveal={{ type: "color", color: "#3730a3" }}
           Icon={FaCode} iconClass="icon-skills"
           color={{ ring: "rgba(99,102,241,0.7)", glow: "rgba(99,102,241,0.35)", label: "rgba(129,140,248,0.9)" }}
         />
         <CTAButton
           label="Projects" href="/projects"
-          reveal={{ type: "color", color: "#065f46" }}
           Icon={FaLayerGroup} iconClass="icon-projects"
           color={{ ring: "rgba(16,185,129,0.7)", glow: "rgba(16,185,129,0.3)", label: "rgba(52,211,153,0.9)" }}
         />
         <CTAButton
           label="Hobbies" href="/hobbies"
-          reveal={{ type: "color", color: "#4c0519" }}
           Icon={FaHeart} iconClass="icon-hobbies"
           color={{ ring: "rgba(244,63,94,0.7)", glow: "rgba(244,63,94,0.3)", label: "rgba(251,113,133,0.9)" }}
         />
         <CTAButton
           label="Articles" href="/articles"
-          reveal={{ type: "color", color: "#2e1065" }}
           Icon={FaFeather} iconClass="icon-articles"
           color={{ ring: "rgba(139,92,246,0.7)", glow: "rgba(139,92,246,0.3)", label: "rgba(167,139,250,0.9)" }}
         />

--- a/src/components/Theme.tsx
+++ b/src/components/Theme.tsx
@@ -28,22 +28,6 @@ export default function Theme() {
 
     const ctx = gsap.context(() => {
       gsap.fromTo(
-        ".theme-tag",
-        { y: 20, opacity: 0 },
-        {
-          y: 0, opacity: 1, duration: 0.6,
-          scrollTrigger: { trigger: sectionRef.current, start: "top 80%" },
-        }
-      );
-      gsap.fromTo(
-        ".theme-version",
-        { y: 20, opacity: 0 },
-        {
-          y: 0, opacity: 1, duration: 0.6, delay: 0.1,
-          scrollTrigger: { trigger: sectionRef.current, start: "top 80%" },
-        }
-      );
-      gsap.fromTo(
         ".theme-heading",
         { x: -280, opacity: 0 },
         {
@@ -114,16 +98,9 @@ export default function Theme() {
       ref={sectionRef}
       id="theme"
       className="w-full"
-      style={{ paddingTop: "14rem", paddingBottom: "8rem" }}
+      style={{ paddingTop: "9rem", paddingBottom: "6rem" }}
     >
       <div className="max-w-5xl mx-auto" style={{ paddingLeft: "clamp(2rem, 5vw, 5rem)", paddingRight: "clamp(2rem, 5vw, 5rem)" }}>
-        {/* ヘッダー行 */}
-        <div className="flex items-baseline justify-between mb-20">
-          <span className="theme-version text-[10px] tracking-[0.3em] uppercase text-white/20">
-            Ver 4.0 Cosmos
-          </span>
-        </div>
-
         {/* バージョンアーカイブ タイムライン */}
         <div className="mb-12">
           <p className="theme-archive-label text-[9px] tracking-[0.4em] uppercase text-white/20 mb-6">Archive</p>

--- a/src/components/TransitionOverlay.tsx
+++ b/src/components/TransitionOverlay.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import gsap from "gsap";
+import { setTransitionTrigger } from "@/lib/pageTransition";
+
+export default function TransitionOverlay() {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const router     = useRouter();
+  const pathname   = usePathname();
+
+  // トリガー関数を登録
+  useEffect(() => {
+    const overlay = overlayRef.current;
+    if (!overlay) return;
+
+    setTransitionTrigger((href: string) => {
+      overlay.style.pointerEvents = "all";
+      gsap.to(overlay, {
+        opacity: 1,
+        duration: 0.35,
+        ease: "power2.inOut",
+        onComplete: () => router.push(href),
+      });
+    });
+  }, [router]);
+
+  // ページ変化時にフェードアウト
+  useEffect(() => {
+    const overlay = overlayRef.current;
+    if (!overlay) return;
+
+    gsap.to(overlay, {
+      opacity: 0,
+      duration: 0.45,
+      ease: "power2.out",
+      delay: 0.05,
+      onComplete: () => { overlay.style.pointerEvents = "none"; },
+    });
+  }, [pathname]);
+
+  return (
+    <div
+      ref={overlayRef}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "#0a0a0a",
+        zIndex: 9999,
+        opacity: 0,
+        pointerEvents: "none",
+      }}
+    />
+  );
+}

--- a/src/lib/pageTransition.ts
+++ b/src/lib/pageTransition.ts
@@ -1,0 +1,14 @@
+// ページ遷移トリガーをグローバルに保持するシングルトン
+let _trigger: ((href: string) => void) | null = null;
+
+export function setTransitionTrigger(fn: (href: string) => void) {
+  _trigger = fn;
+}
+
+export function navigateTo(href: string) {
+  if (_trigger) {
+    _trigger(href);
+  } else {
+    window.location.href = href;
+  }
+}


### PR DESCRIPTION
## 概要
- ページ遷移時に画面が黒くフェードアウト→フェードインするアニメーションを実装
- ScrollCTAのサークルリビールをフェードトランジションに統一
- Navigationメニューのリンクにも同様のフェード遷移を適用
- トップページのセクション間余白を縮小（14rem→9rem / 8rem→6rem）

## 変更の背景・目的
ページ遷移のアクションを改善し、サイト全体の体験に統一感を持たせるため。

## テスト項目
- [ ] ビルドが通ること
- [ ] ScrollCTAボタンクリック時にフェード遷移が動作すること
- [ ] Navigationリンククリック時にフェード遷移が動作すること
- [ ] 新しいページ表示時にフェードインが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)