### PR TITLE
fix: 同一ページへの遷移でオーバーレイがフリーズする問題を修正

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -270,7 +270,7 @@ export default function Navigation() {
                   e.preventDefault();
                   setMenuOpen(false);
                   lenisInstance?.scrollTo(0, { immediate: true });
-                  navigateTo(link.href);
+                  if (pathname !== link.href) navigateTo(link.href);
                 }}
               >
                 {/* D: ホバーで他リンクが暗くなる */}

--- a/src/components/ScrollCTA.tsx
+++ b/src/components/ScrollCTA.tsx
@@ -3,6 +3,7 @@
 import { useRef } from "react";
 import { gsap } from "gsap";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { FaCode, FaLayerGroup, FaHeart, FaFeather } from "react-icons/fa";
 import type { IconType } from "react-icons";
 import { navigateTo } from "@/lib/pageTransition";
@@ -20,6 +21,7 @@ function CTAButton({
   color: ButtonColor;
 }) {
   const btnRef = useRef<HTMLAnchorElement>(null);
+  const pathname = usePathname();
 
   const handleMouseEnter = () => {
     const el = btnRef.current;
@@ -51,6 +53,7 @@ function CTAButton({
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
+    if (pathname === href) return;
     navigateTo(href);
   };
 

--- a/src/components/TransitionOverlay.tsx
+++ b/src/components/TransitionOverlay.tsx
@@ -5,10 +5,15 @@ import { useRouter, usePathname } from "next/navigation";
 import gsap from "gsap";
 import { setTransitionTrigger, setRouterPush } from "@/lib/pageTransition";
 
+const normalize = (p: string) => p.replace(/\/$/, "") || "/";
+
 export default function TransitionOverlay() {
-  const overlayRef = useRef<HTMLDivElement>(null);
-  const router     = useRouter();
-  const pathname   = usePathname();
+  const overlayRef   = useRef<HTMLDivElement>(null);
+  const router       = useRouter();
+  const pathname     = usePathname();
+  const pathnameRef  = useRef(pathname);
+
+  useEffect(() => { pathnameRef.current = pathname; }, [pathname]);
 
   // トリガー関数を登録
   useEffect(() => {
@@ -19,6 +24,9 @@ export default function TransitionOverlay() {
     if (!overlay) return;
 
     setTransitionTrigger((href: string) => {
+      // 同一ページへの遷移はフリーズするためスキップ
+      if (normalize(href) === normalize(pathnameRef.current)) return;
+
       overlay.style.pointerEvents = "all";
       gsap.to(overlay, {
         opacity: 1,


### PR DESCRIPTION
## 概要
- `TransitionOverlay` に `pathnameRef` を追加し、クロージャーが常に最新の pathname を参照するよう修正
- 末尾スラッシュを正規化して比較することで `trailingSlash: true` 環境でも正しく動作するよう対応
- `ScrollCTA` と `Navigation` でも同一ページへの遷移を事前にガード

## 変更の背景・目的
スキルページ等で現在表示中のページへのボタンを押すと、オーバーレイが暗転したまま pathname が変化しないためフェードアウトが発火せずフリーズしていた

## テスト項目
- [ ] ビルドが通ること
- [ ] 同一ページのボタンを押しても暗転・フリーズしないこと
- [ ] 別ページへの遷移は正常にフェードイン/アウトすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)