### PR TITLE
feat: 記事詳細ページのUI・レイアウト全面改善

### DIFF
--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -2,6 +2,9 @@ import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { getArticles, getArticle } from "@/lib/notion";
+import { extractHeadings, slugify } from "@/lib/headings";
+import ArticleToc from "@/components/ArticleToc";
+import ArticleBackground from "@/components/ArticleBackground";
 
 export const revalidate = false;
 
@@ -17,73 +20,152 @@ function formatDate(dateStr: string) {
   });
 }
 
+// ReactMarkdown用の見出しコンポーネントファクトリ（extractHeadingsと同じ重複解決ロジック）
+const HEADING_MARGIN: Record<number, string> = {
+  1: "2rem",
+  2: "2.5rem",
+  3: "1.75rem",
+  4: "1.5rem",
+};
+
+function makeHeadingComponents() {
+  const seen = new Map<string, number>();
+  const make = (level: 1 | 2 | 3 | 4 | 5 | 6) => {
+    const Tag = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return function HeadingComponent({ children }: any) {
+      const text = typeof children === "string" ? children
+        : Array.isArray(children) ? children.join("") : "";
+      const base = slugify(text);
+      const count = seen.get(base) ?? 0;
+      const id = count === 0 ? base : `${base}-${count}`;
+      seen.set(base, count + 1);
+      return <Tag id={id} style={{ marginTop: HEADING_MARGIN[level] ?? "2rem", marginBottom: "0.75rem" }}>{children}</Tag>;
+    };
+  };
+  return { h1: make(1), h2: make(2), h3: make(3), h4: make(4) };
+}
+
 export default async function ArticlePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const { article, content } = await getArticle(id);
+  const headings = extractHeadings(content);
+  const headingComponents = makeHeadingComponents();
 
   return (
-    <main className="min-h-screen w-full" style={{ paddingTop: "10rem", paddingBottom: "8rem" }}>
-      <div className="max-w-3xl mx-auto" style={{ paddingLeft: "clamp(2rem, 5vw, 5rem)", paddingRight: "clamp(2rem, 5vw, 5rem)" }}>
-
-        {/* Back */}
-        <Link
-          href="/articles"
-          className="inline-flex items-center gap-3 text-white/30 hover:text-white/70 transition-colors duration-300 mb-16 text-[11px] tracking-[0.3em] uppercase"
-        >
-          ← Articles
-        </Link>
-
-        {/* Meta */}
-        <div className="mb-12">
-          {article.tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mb-6">
-              {article.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="text-[10px] tracking-[0.2em] uppercase text-indigo-400/60 border border-indigo-400/20 px-2 py-0.5 rounded-full"
-                >
-                  {tag}
-                </span>
-              ))}
+    <main className="min-h-screen w-full relative" style={{ paddingTop: "10rem", paddingBottom: "8rem" }}>
+      <ArticleBackground />
+      <div
+        style={{
+          maxWidth: "48rem",
+          marginLeft: "auto",
+          marginRight: "auto",
+          paddingLeft: "clamp(2rem, 5vw, 5rem)",
+          paddingRight: "clamp(2rem, 5vw, 5rem)",
+          position: "relative",
+          zIndex: 1,
+        }}
+      >
+        {/* メインコンテンツ */}
+        <div>
+            {/* Meta */}
+            <div style={{ marginBottom: "2.5rem" }}>
+              {article.tags.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-6">
+                  {article.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="text-[10px] tracking-[0.2em] uppercase text-indigo-400/60 border border-indigo-400/20 px-2 py-0.5 rounded-full"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <h1 className="text-3xl md:text-4xl font-black leading-tight tracking-tight text-white mb-4">
+                {article.title}
+              </h1>
+              <p className="text-sm font-mono text-white/50">
+                {formatDate(article.date)}
+              </p>
             </div>
-          )}
-          <h1 className="text-3xl md:text-4xl font-black leading-tight tracking-tight text-white mb-4">
-            {article.title}
-          </h1>
-          <p className="text-[11px] tracking-[0.25em] uppercase text-white/25">
-            {formatDate(article.date)}
-          </p>
-        </div>
 
-        <div className="h-px bg-white/[0.06] mb-12" />
+            <div className="h-px bg-white/[0.06]" style={{ marginBottom: "2.5rem" }} />
 
-        {/* Content */}
-        <div className="prose prose-invert prose-sm md:prose-base max-w-none
-          prose-headings:font-bold prose-headings:tracking-tight prose-headings:text-white/90
-          prose-p:text-white/60 prose-p:leading-relaxed
-          prose-a:text-indigo-400 prose-a:no-underline hover:prose-a:underline
-          prose-strong:text-white/80
-          prose-code:text-indigo-300 prose-code:bg-white/[0.06] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-normal
-          prose-pre:bg-white/[0.04] prose-pre:border prose-pre:border-white/[0.08]
-          prose-blockquote:border-l-indigo-500/50 prose-blockquote:text-white/40
-          prose-hr:border-white/[0.06]
-          prose-li:text-white/60"
-        >
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
-            {content}
-          </ReactMarkdown>
-        </div>
+            {/* Content */}
+            <div className="prose prose-invert prose-sm md:prose-base max-w-none
+              prose-headings:font-bold prose-headings:tracking-tight prose-headings:text-white/90
+              prose-p:text-white/60 prose-p:leading-relaxed
+              prose-a:text-indigo-400 prose-a:no-underline hover:prose-a:underline
+              prose-strong:text-white/80
+              prose-code:text-indigo-300 prose-code:bg-white/[0.06] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-normal
+              prose-pre:bg-white/[0.04] prose-pre:border prose-pre:border-white/[0.08]
+              prose-blockquote:border-l-indigo-500/50 prose-blockquote:text-white/40
+              prose-hr:border-white/[0.06]
+              prose-li:text-white/60"
+            >
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  ...headingComponents,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  img: ({ src, alt }: any) => (
+                    <img src={src} alt={alt ?? ""} style={{ marginTop: "2rem", marginBottom: "2rem", borderRadius: "0.5rem" }} />
+                  ),
+                  table: ({ children }: any) => (
+                    <div style={{ overflowX: "auto", margin: "2rem 0" }}>
+                      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem" }}>
+                        {children}
+                      </table>
+                    </div>
+                  ),
+                  thead: ({ children }: any) => (
+                    <thead style={{ borderBottom: "1px solid rgba(99,102,241,0.3)" }}>{children}</thead>
+                  ),
+                  th: ({ children }: any) => (
+                    <th style={{ padding: "0.6rem 1rem", textAlign: "left", color: "rgba(129,140,248,0.8)", fontWeight: 600, fontSize: "0.75rem", letterSpacing: "0.1em", whiteSpace: "nowrap" }}>
+                      {children}
+                    </th>
+                  ),
+                  tr: ({ children }: any) => (
+                    <tr style={{ borderBottom: "1px solid rgba(255,255,255,0.05)" }}>{children}</tr>
+                  ),
+                  td: ({ children }: any) => (
+                    <td style={{ padding: "0.6rem 1rem", color: "rgba(255,255,255,0.6)", verticalAlign: "top" }}>
+                      {children}
+                    </td>
+                  ),
+                  ul: ({ children }: any) => (
+                    <ul style={{ margin: "1.25rem 0", padding: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: "0.4rem" }}>
+                      {children}
+                    </ul>
+                  ),
+                  ol: ({ children }: any) => (
+                    <ol style={{ margin: "1.25rem 0", paddingLeft: "1.5rem", display: "flex", flexDirection: "column", gap: "0.4rem", color: "rgba(255,255,255,0.65)", fontSize: "0.925rem", lineHeight: "1.7" }}>
+                      {children}
+                    </ol>
+                  ),
+                  li: ({ children, ordered }: any) => ordered ? (
+                    <li style={{ color: "rgba(255,255,255,0.65)", lineHeight: "1.7", paddingLeft: "0.25rem" }}>
+                      {children}
+                    </li>
+                  ) : (
+                    <li style={{ display: "flex", gap: "0.75rem", alignItems: "baseline", color: "rgba(255,255,255,0.65)", fontSize: "0.925rem", lineHeight: "1.7" }}>
+                      <span style={{ flexShrink: 0, color: "rgba(99,102,241,0.7)", fontSize: "0.7rem", paddingTop: "0.25rem" }}>▸</span>
+                      <span>{children}</span>
+                    </li>
+                  ),
+                }}
+              >
+                {content}
+              </ReactMarkdown>
+            </div>
 
-        {/* Footer */}
-        <div className="mt-20 pt-10 border-t border-white/[0.06]">
-          <Link
-            href="/articles"
-            className="inline-flex items-center gap-3 text-white/30 hover:text-white/70 transition-colors duration-300 text-[11px] tracking-[0.3em] uppercase"
-          >
-            ← 記事一覧に戻る
-          </Link>
         </div>
       </div>
+
+      {/* ToC: fixed で右端に浮かせる */}
+      {headings.length > 0 && <ArticleToc headings={headings} />}
     </main>
   );
 }

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -11,7 +11,7 @@ export default async function ArticlesPage() {
   return (
     <main className="min-h-screen w-full relative" style={{ paddingTop: "10rem", paddingBottom: "18rem" }}>
       <ArticlesBackground />
-      <div className="relative z-10 max-w-5xl mx-auto" style={{ paddingLeft: "clamp(2rem, 5vw, 5rem)", paddingRight: "clamp(2rem, 5vw, 5rem)" }}>
+      <div style={{ maxWidth: "72rem", marginLeft: "auto", marginRight: "auto", paddingLeft: "clamp(2rem, 5vw, 5rem)", paddingRight: "clamp(2rem, 5vw, 5rem)", position: "relative", zIndex: 10 }}>
 
         <ArticlesHeader count={articles.length} />
 

--- a/src/components/ArticleBackground.tsx
+++ b/src/components/ArticleBackground.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export default function ArticleBackground() {
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const total = document.body.scrollHeight - window.innerHeight;
+      const progress = total > 0 ? window.scrollY / total : 0;
+      if (barRef.current) {
+        barRef.current.style.height = `${progress * 100}%`;
+      }
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "fixed",
+        left: 0,
+        top: 0,
+        width: "2px",
+        height: "100vh",
+        zIndex: 50,
+        background: "rgba(255,255,255,0.04)",
+      }}
+    >
+      <div
+        ref={barRef}
+        style={{
+          width: "100%",
+          height: "0%",
+          background: "linear-gradient(to bottom, #6366f1, #a78bfa)",
+          transition: "height 0.05s linear",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/ArticleToc.tsx
+++ b/src/components/ArticleToc.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Heading } from "@/lib/headings";
+
+export default function ArticleToc({ headings }: { headings: Heading[] }) {
+  const [activeId, setActiveId] = useState("");
+
+  useEffect(() => {
+    if (!headings.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // 最上部に近いものをアクティブに
+        const visible = entries.filter((e) => e.isIntersecting);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "-10% 0% -80% 0%", threshold: 0 }
+    );
+
+    headings.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [headings]);
+
+  if (!headings.length) return null;
+
+  return (
+    <aside
+      className="hidden xl:block"
+      style={{
+        position: "fixed",
+        top: "8rem",
+        right: "clamp(1.5rem, 3vw, 4rem)",
+        width: "180px",
+        zIndex: 10,
+      }}
+    >
+      <nav>
+        <p
+          className="mb-4"
+          style={{
+            fontSize: "9px",
+            letterSpacing: "0.3em",
+            textTransform: "uppercase",
+            color: "rgba(255,255,255,0.2)",
+          }}
+        >
+          目次
+        </p>
+
+        <ul className="space-y-1">
+          {headings.map(({ id, text, level }) => {
+            const isActive = activeId === id;
+            return (
+              <li key={id}>
+                <a
+                  href={`#${id}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  }}
+                  style={{
+                    display: "block",
+                    paddingLeft: level === 2 ? "0.75rem" : level === 3 ? "1.25rem" : "1.75rem",
+                    fontSize: "11px",
+                    lineHeight: "1.5",
+                    color: isActive ? "rgba(129,140,248,0.9)" : "rgba(255,255,255,0.25)",
+                    transition: "color 0.2s ease",
+                    paddingTop: "0.2rem",
+                    paddingBottom: "0.2rem",
+                    borderLeft: isActive ? "1px solid rgba(99,102,241,0.5)" : "1px solid transparent",
+                  }}
+                >
+                  {text}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/src/lib/headings.ts
+++ b/src/lib/headings.ts
@@ -1,0 +1,27 @@
+export type Heading = { id: string; text: string; level: number };
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .trim();
+}
+
+export function extractHeadings(markdown: string): Heading[] {
+  const regex = /^(#{1,3})\s+(.+)$/gm;
+  const headings: Heading[] = [];
+  const seen = new Map<string, number>();
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(markdown)) !== null) {
+    const level = match[1].length;
+    const text = match[2].trim();
+    const base = slugify(text);
+    const count = seen.get(base) ?? 0;
+    const id = count === 0 ? base : `${base}-${count}`;
+    seen.set(base, count + 1);
+    headings.push({ id, text, level });
+  }
+  return headings;
+}


### PR DESCRIPTION
## 概要
- 目次（ToC）コンポーネントを追加し、画面右端に固定表示・スクロール連動でアクティブ見出しをハイライト
- 左端にスクロール進捗バーを追加（インジゴ→バイオレットのグラデーション）
- 見出し・段落・表・箇条書き・画像のスタイルをカスタムコンポーネントで改善
- 記事一覧・詳細ページのコンテンツを中央揃えに修正

## 変更の背景・目的
記事ページのレイアウトが単調でマークダウンの構造が活かされていなかったため、読書体験を向上させる

## テスト項目
- [ ] ビルドが通ること
- [ ] 目次が正しく表示・ハイライトされること
- [ ] スクロール進捗バーが動作すること
- [ ] 表・箇条書き・画像が正しくスタイリングされること
- [ ] 記事一覧・詳細ページが中央揃えで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)